### PR TITLE
No longer mutate the passed-in array within fromObjects, fromErroredO…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const StreamTest = {
       return StreamTest.v1.fromErroredObjects.apply(this, arguments);
     },
     __emitToStream: function v1EmitToStream(stream, chunks, timeout, endcb) {
+      chunks = chunks.slice();
       setTimeout(() => {
         if (!chunks.length) {
           setTimeout(stream.emit.bind(stream, 'end'), timeout || 0);
@@ -127,7 +128,7 @@ const StreamTest = {
     fromObjects: function v2FromObjects(objects, timeout) {
       const stream = StreamTest.v2.readable({ objectMode: true });
 
-      objects = objects || [];
+      objects = objects ? objects.slice() : [];
       stream._read = () => {
         let object = null;
 
@@ -143,7 +144,7 @@ const StreamTest = {
     fromErroredObjects: function v2FromErroredObjects(err, objects, timeout) {
       const stream = StreamTest.v2.readable({ objectMode: true });
 
-      objects = objects || [];
+      objects = objects ? objects.slice() : [];
       stream._read = () => {
         let object = null;
 
@@ -163,7 +164,7 @@ const StreamTest = {
     fromChunks: function v2FromChunks(chunks, timeout) {
       const stream = StreamTest.v2.readable();
 
-      chunks = chunks || [];
+      chunks = chunks ? chunks.slice() : [];
       stream._read = () => {
         let chunk = null;
 
@@ -179,7 +180,7 @@ const StreamTest = {
     fromErroredChunks: function v2FromErroredChunks(err, chunks, timeout) {
       const stream = StreamTest.v2.readable();
 
-      chunks = chunks || [];
+      chunks = chunks ? chunks.slice() : [];
       stream._read = () => {
         let chunk = null;
 

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -15,9 +15,7 @@ describe('StreamTest', () => {
     describe('for ' + version + ' streams', () => {
       it('should work with buffers', done => {
         const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
-        const inputStream = StreamTest[version].fromChunks(
-          expectedBuffers.slice(0)
-        );
+        const inputStream = StreamTest[version].fromChunks(expectedBuffers);
         const outputStream = StreamTest[version].toChunks((err, buffers) => {
           if (err) {
             done(err);
@@ -34,7 +32,7 @@ describe('StreamTest', () => {
         const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
         const inputStream = StreamTest[version].fromErroredChunks(
           new Error('Ooops'),
-          expectedBuffers.slice(0)
+          expectedBuffers
         );
         const outputStream = StreamTest[version].toChunks((err, buffers) => {
           assert(err);
@@ -50,9 +48,7 @@ describe('StreamTest', () => {
 
       it('should work when wanting whole text', done => {
         const expectedBuffers = ['test', 'test2'];
-        const inputStream = StreamTest[version].fromObjects(
-          expectedBuffers.slice(0)
-        );
+        const inputStream = StreamTest[version].fromObjects(expectedBuffers);
         const outputStream = StreamTest[version].toText((err, buffers) => {
           if (err) {
             done(err);
@@ -69,7 +65,7 @@ describe('StreamTest', () => {
         const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
         const inputStream = StreamTest[version].fromErroredChunks(
           new Error('Ooops'),
-          expectedBuffers.slice(0)
+          expectedBuffers
         );
         const outputStream = StreamTest[version].toText((err, buffers) => {
           assert(err);
@@ -93,9 +89,7 @@ describe('StreamTest', () => {
             test: 'test2',
           },
         ];
-        const inputStream = StreamTest[version].fromObjects(
-          expectedObjs.slice(0)
-        );
+        const inputStream = StreamTest[version].fromObjects(expectedObjs);
         const outputStream = StreamTest[version].toObjects((err, objs) => {
           if (err) {
             done(err);
@@ -119,7 +113,7 @@ describe('StreamTest', () => {
         ];
         const inputStream = StreamTest[version].fromErroredObjects(
           new Error('Ooops'),
-          expectedObjs.slice(0)
+          expectedObjs
         );
         const outputStream = StreamTest[version].toObjects((err, objs) => {
           assert(err);


### PR DESCRIPTION
…bjects, fromChunks, and fromErroredChunks

<!--

Thanks for improving this project!

Before doing so, there are a few checks to do in
 order to get your PR merged asap. Just fill in the
 following template.

-->

### Proposed changes
- The array of `chunks` or `objects` passed into `fromObjects`, `fromErroredObjects`, `fromChunks`, or `fromErroredChunks` is no longer mutated, allowing the array to be used multiple times.

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [x] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

(Note: I would have added to contributors if it existed. I also don't care about the credit for this small change.)

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

<!--

If you already maintain several NPM modules / NodeJS
 project, making significant changes on one of my modules
 automatically legitimates you as a core developer.

This is because i could die or even not give a shit to
 this project someday and i don't want people to get
 stuck.

If you want to help, fill the following with to get
GitHub/NPM r/w access.

-->
### Join
- [ ] I wish to join the core team
- [ ] I agree that with great powers comes responsibilities
- [ ] I'm a nice person

My NPM username: `ckknight`
