### PR TITLE
Replace new Buffer by Buffer.from

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ const StreamTest = {
       const stream = StreamTest.v1.writable();
 
       stream.write = chunk => {
-        chunks.push(new Buffer(chunk));
+        chunks.push(Buffer.from(chunk));
       };
       stream.end = () => {
         cb(null, chunks);
@@ -224,7 +224,7 @@ const StreamTest = {
 
       stream._write = (chunk, encoding, done) => {
         if (encoding && 'buffer' !== encoding) {
-          chunk = new Buffer(chunk.toString(encoding));
+          chunk = Buffer.from(chunk.toString(encoding));
         }
         chunks.push(chunk);
         done();

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -14,7 +14,7 @@ describe('StreamTest', () => {
   StreamTest.versions.forEach(version => {
     describe('for ' + version + ' streams', () => {
       it('should work with buffers', done => {
-        const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
+        const expectedBuffers = [Buffer.from('test'), Buffer.from('test2')];
         const inputStream = StreamTest[version].fromChunks(expectedBuffers);
         const outputStream = StreamTest[version].toChunks((err, buffers) => {
           if (err) {
@@ -29,7 +29,7 @@ describe('StreamTest', () => {
       });
 
       it('should report errors with buffers', done => {
-        const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
+        const expectedBuffers = [Buffer.from('test'), Buffer.from('test2')];
         const inputStream = StreamTest[version].fromErroredChunks(
           new Error('Ooops'),
           expectedBuffers
@@ -62,7 +62,7 @@ describe('StreamTest', () => {
       });
 
       it('should report errors when wanting whole text', done => {
-        const expectedBuffers = [new Buffer('test'), new Buffer('test2')];
+        const expectedBuffers = [Buffer.from('test'), Buffer.from('test2')];
         const inputStream = StreamTest[version].fromErroredChunks(
           new Error('Ooops'),
           expectedBuffers


### PR DESCRIPTION
This avoids the deprecation warning with node >= 12
### License
- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license
